### PR TITLE
Player API update

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -97,6 +97,12 @@ m4_foreach_w([player],
   fi
 ])
 
+# Player probe support
+AC_ARG_ENABLE(player-probe,
+  AS_HELP_STRING([--enable-player-probe=[yes|no]], [Enable or disable player probe support [default=auto]]),
+  [player_probe="$enableval"],
+  [player_probe=""])
+
 # Audacious plugin
 AC_ARG_ENABLE(plugin-audacious,
   AS_HELP_STRING([--enable-plugin-audacious=[yes|no|auto]], [Explicitly enable or disable Audacious plugin [default=auto]]),
@@ -124,6 +130,10 @@ PKG_CHECK_MODULES([AUDACIOUS],[audacious >= 3.8],
 fi
 
 if test "$plugin_audacious" = "yes"; then
+if test "$player_probe" = "no"; then
+  AC_MSG_ERROR([Player probe support is required for Audacious plugin])
+fi
+player_probe="yes"
 AC_MSG_CHECKING([for audacious plugindir])
 AC_ARG_WITH([audacious-plugindir],
   AS_HELP_STRING([--with-audacious-plugindir=[PLUGINDIR]], [Installs uade plugin under [PLUGINDIR]/Input instead of Audacious default]),
@@ -170,6 +180,11 @@ AC_COMPILE_IFELSE(
 AC_LANG_POP
 CXXFLAGS="$saved_cxxflags"
 fi
+
+if test "$player_probe" = "yes"; then
+  AC_DEFINE([PLAYER_PROBE], [1], [Enable player probe support])
+fi
+AM_CONDITIONAL([PLAYER_PROBE], [test "$player_probe" = "yes"])
 
 AM_CONDITIONAL([PLUGIN_AUDACIOUS], [test "$plugin_audacious" = "yes"])
 

--- a/src/3rdparty/Makefile.am.inc
+++ b/src/3rdparty/Makefile.am.inc
@@ -52,8 +52,11 @@ noinst_LTLIBRARIES += 3rdparty/replay/libreplay_ft2play.la
 
 3rdparty_replay_libreplay_ft2play_la_SOURCES = \
     3rdparty/replay/ft2play/ft2play.h \
-    3rdparty/replay/ft2play/ft2play_play.cc \
-    3rdparty/replay/ft2play/ft2play_probe.cc
+    3rdparty/replay/ft2play/ft2play_play.cc
+
+if PLAYER_PROBE
+3rdparty_replay_libreplay_ft2play_la_SOURCES += 3rdparty/replay/ft2play/ft2play_probe.cc
+endif
 
 3rdparty/replay/ft2play/% : CXXFLAGS += -Wno-volatile -Wno-unknown-warning-option
 endif
@@ -64,8 +67,11 @@ noinst_LTLIBRARIES += 3rdparty/replay/libreplay_st3play.la
 
 3rdparty_replay_libreplay_st3play_la_SOURCES = \
     3rdparty/replay/st3play/st3play.h \
-    3rdparty/replay/st3play/st3play_play.cc \
-    3rdparty/replay/st3play/st3play_probe.cc
+    3rdparty/replay/st3play/st3play_play.cc
+
+if PLAYER_PROBE
+3rdparty_replay_libreplay_st3play_la_SOURCES += 3rdparty/replay/st3play/st3play_probe.cc
+endif
 
 3rdparty/replay/st3play/% : CXXFLAGS += -Wno-keyword-macro
 endif
@@ -76,8 +82,11 @@ noinst_LTLIBRARIES += 3rdparty/replay/libreplay_it2play.la
 
 3rdparty_replay_libreplay_it2play_la_SOURCES = \
     3rdparty/replay/it2play/it2play.h \
-    3rdparty/replay/it2play/it2play_play.cc \
-    3rdparty/replay/it2play/it2play_probe.cc
+    3rdparty/replay/it2play/it2play_play.cc
+
+if PLAYER_PROBE
+3rdparty_replay_libreplay_it2play_la_SOURCES += 3rdparty/replay/it2play/it2play_probe.cc
+endif
 
 3rdparty/replay/it2play/% : CXXFLAGS += -Wno-misleading-indentation
 endif
@@ -88,8 +97,11 @@ noinst_LTLIBRARIES += 3rdparty/replay/libreplay_st23play.la
 
 3rdparty_replay_libreplay_st23play_la_SOURCES = \
     3rdparty/replay/st23play/st23play.h \
-    3rdparty/replay/st23play/st23play_play.cc \
-    3rdparty/replay/st23play/st23play_probe.cc
+    3rdparty/replay/st23play/st23play_play.cc
+
+if PLAYER_PROBE
+3rdparty_replay_libreplay_st23play_la_SOURCES += 3rdparty/replay/st23play/st23play_probe.cc
+endif
 endif
 
 if PLAYER_noisetrekker2
@@ -97,8 +109,11 @@ noinst_LTLIBRARIES += 3rdparty/replay/libreplay_noisetrekker2.la
 3rdparty_libreplay_la_LIBADD += 3rdparty/replay/libreplay_noisetrekker2.la
 3rdparty_replay_libreplay_noisetrekker2_la_SOURCES = \
     3rdparty/replay/noisetrekker2/noisetrekker2.h \
-    3rdparty/replay/noisetrekker2/noisetrekker2_play.cc \
-    3rdparty/replay/noisetrekker2/noisetrekker2_probe.cc
+    3rdparty/replay/noisetrekker2/noisetrekker2_play.cc 
+
+if PLAYER_PROBE
+3rdparty_replay_libreplay_noisetrekker2_la_SOURCES += 3rdparty/replay/noisetrekker2/noisetrekker2_probe.cc
+endif
 
 3rdparty/replay/noisetrekker2/% : CXXFLAGS += -Wno-char-subscripts -Wno-unused -Wno-sign-compare -Wno-deprecated-declarations -Wno-type-limits
 endif
@@ -109,8 +124,11 @@ noinst_LTLIBRARIES += 3rdparty/replay/libreplay_protrekkr1.la
 
 3rdparty_replay_libreplay_protrekkr1_la_SOURCES = \
     3rdparty/replay/protrekkr1/protrekkr1.h \
-    3rdparty/replay/protrekkr1/protrekkr1_play.cc \
-    3rdparty/replay/protrekkr1/protrekkr1_probe.cc
+    3rdparty/replay/protrekkr1/protrekkr1_play.cc
+
+if PLAYER_PROBE
+3rdparty_replay_libreplay_protrekkr1_la_SOURCES += 3rdparty/replay/protrekkr1/protrekkr1_probe.cc
+endif
 
 3rdparty/replay/protrekkr1/% : CXXFLAGS += -Wno-char-subscripts -Wno-unused -Wno-sign-compare -Wno-multichar -Wno-implicit-fallthrough -Wno-type-limits -Wno-volatile -Wno-unknown-warning-option
 endif
@@ -121,8 +139,11 @@ noinst_LTLIBRARIES += 3rdparty/replay/libreplay_protrekkr2.la
 
 3rdparty_replay_libreplay_protrekkr2_la_SOURCES = \
     3rdparty/replay/protrekkr2/protrekkr2.h \
-    3rdparty/replay/protrekkr2/protrekkr2_play.cc \
-    3rdparty/replay/protrekkr2/protrekkr2_probe.cc
+    3rdparty/replay/protrekkr2/protrekkr2_play.cc
+
+if PLAYER_PROBE
+3rdparty_replay_libreplay_protrekkr2_la_SOURCES += 3rdparty/replay/protrekkr2/protrekkr2_probe.cc
+endif
 
 3rdparty/replay/protrekkr2/% : CXXFLAGS += -Wno-char-subscripts -Wno-unused -Wno-sign-compare -Wno-multichar -Wno-implicit-fallthrough -Wno-volatile -Wno-unknown-warning-option
 endif

--- a/src/3rdparty/replay/ft2play/ft2play.h
+++ b/src/3rdparty/replay/ft2play/ft2play.h
@@ -29,6 +29,8 @@ inline void unlockMixer(void) {}
 inline bool openMixer(int32_t mixingFrequency, int32_t mixingBufferSize) { assert(false); return false; }
 inline void closeMixer(void) {}
 }
+
+#ifdef PLAYER_PROBE
 namespace replay::ft2play::probe {
 #include "pmplay.h"
 #include "pmp_mix.h"
@@ -39,3 +41,6 @@ inline void unlockMixer(void) {}
 inline bool openMixer(int32_t mixingFrequency, int32_t mixingBufferSize) { assert(false); return false; }
 inline void closeMixer(void) {}
 }
+#else
+namespace replay::ft2play { namespace probe = replay::ft2play::play; }
+#endif

--- a/src/3rdparty/replay/it2play/it2play.h
+++ b/src/3rdparty/replay/it2play/it2play.h
@@ -39,6 +39,7 @@ inline bool openMixer(int32_t mixingFrequency, int32_t mixingBufferSize) { retur
 inline void closeMixer(void) {}
 } // namespace replay::it2play::play
 
+#ifdef PLAYER_PROBE
 namespace replay::it2play::probe {
 using namespace replay::it2play;
 extern hostChn_t hChn[MAX_HOST_CHANNELS];
@@ -56,3 +57,6 @@ inline void unlockMixer(void) {}
 inline bool openMixer(int32_t mixingFrequency, int32_t mixingBufferSize) { return true; }
 inline void closeMixer(void) {}
 } // namespace replay::it2play::probe
+#else
+namespace replay::it2play { namespace probe = replay::it2play::play; }
+#endif

--- a/src/3rdparty/replay/noisetrekker2/noisetrekker2.h
+++ b/src/3rdparty/replay/noisetrekker2/noisetrekker2.h
@@ -94,6 +94,10 @@ void ComputeStereo(char channel); \
 void reset() noexcept; \
 
 namespace play { NOISETREKKER2_NS }
+#ifdef PLAYER_PROBE
 namespace probe { NOISETREKKER2_NS }
+#else
+namespace probe = play;
+#endif
 
 } // namespace replay::noisetrekker2

--- a/src/3rdparty/replay/protrekkr1/protrekkr1.h
+++ b/src/3rdparty/replay/protrekkr1/protrekkr1.h
@@ -114,6 +114,7 @@ namespace play {
 PROTREKKR_NS
 } // namespace play
 
+#ifdef PLAYER_PROBE
 namespace probe {
 #include "release/distrib/replay/lib/include/synth.h"
 #include "release/distrib/replay/lib/include/tb_303.h"
@@ -122,6 +123,9 @@ namespace probe {
 #include "src/editors/include/patterns_blocks.h"
 PROTREKKR_NS
 } // namespace probe
+#else
+namespace probe = play;
+#endif
 
 } // namespace replay::protrekkr1
 

--- a/src/3rdparty/replay/protrekkr2/protrekkr2.h
+++ b/src/3rdparty/replay/protrekkr2/protrekkr2.h
@@ -119,6 +119,7 @@ namespace play {
 PROTREKKR_NS
 } // namespace play
 
+#ifdef PLAYER_PROBE
 namespace probe {
 #include "release/distrib/replay/lib/include/synth.h"
 #include "release/distrib/replay/lib/include/tb_303.h"
@@ -127,5 +128,7 @@ namespace probe {
 #include "src/editors/include/patterns_blocks.h"
 PROTREKKR_NS
 } // namespace probe
-
+#else
+namespace probe = play;
+#endif
 } // namespace replay::protrekkr2

--- a/src/3rdparty/replay/st23play/st23play.h
+++ b/src/3rdparty/replay/st23play/st23play.h
@@ -30,4 +30,8 @@ inline void clearMixBuffer() { \
 }
 
 ST23PLAY(replay::st23play::play)
+#ifdef PLAYER_PROBE
 ST23PLAY(replay::st23play::probe)
+#else
+namespace replay::st23play { namespace probe = replay::st23play::play; }
+#endif

--- a/src/3rdparty/replay/st3play/st3play.h
+++ b/src/3rdparty/replay/st3play/st3play.h
@@ -39,4 +39,8 @@ inline void clearMixBuffer() { \
 }
 
 ST3PLAY(replay::st3play::play)
+#ifdef PLAYER_PROBE
 ST3PLAY(replay::st3play::probe)
+#else
+namespace replay::st3play { namespace probe = replay::st3play::play; }
+#endif

--- a/src/player/player.cc
+++ b/src/player/player.cc
@@ -99,7 +99,7 @@ Player check(const char *path, const char *buf, size_t size) noexcept {
     return Player::NONE;
 }
 
-optional<ModuleInfo> parse(const char *path, const char *buf, size_t size) noexcept {
+optional<ModuleInfo> parse(const char *path, const char *buf, size_t size, Player player/* = Player::NONE*/) noexcept {
     assert(initialized);
     if (size < MAGIC_SIZE || size < converter::MAGIC_SIZE) return {};
     assert(path);
@@ -114,7 +114,7 @@ optional<ModuleInfo> parse(const char *path, const char *buf, size_t size) noexc
         buf = conversion->data.data();
         size = conversion->data.size();
     }
-    Player player = check(path, buf, size);
+    if (player == Player::NONE) player = check(path, buf, size);
     if (player == Player::NONE) return {};
     optional<ModuleInfo> res;
     SWITCH_PLAYER(player, res,
@@ -127,8 +127,8 @@ optional<ModuleInfo> parse(const char *path, const char *buf, size_t size) noexc
 }
 
 optional<PlayerState> play(const char *path, const char *buf, size_t size, int subsong, const PlayerConfig &config) noexcept {
-    assert(initialized);
     if (size < MAGIC_SIZE || size < converter::MAGIC_SIZE) return {};
+    assert(initialized);
     assert(path);
     assert(buf);
     assert(subsong >= 0);
@@ -142,7 +142,8 @@ optional<PlayerState> play(const char *path, const char *buf, size_t size, int s
         buf = conversion->data.data();
         size = conversion->data.size();
     }
-    Player player = check(path, buf, size);
+    Player player = config.player;
+    if (player == Player::NONE) player = check(path, buf, size);
     if (player == Player::NONE) return {};
     optional<PlayerState> res;
     SWITCH_PLAYER(player, res,

--- a/src/player/player.h
+++ b/src/player/player.h
@@ -84,11 +84,12 @@ struct PlayerConfig {
     bool probe = false;
 
     constexpr_f1 PlayerConfig() noexcept {}
-    constexpr_f1 PlayerConfig(const int frequency) noexcept : frequency(frequency) {}
-    constexpr_f1 PlayerConfig(const int frequency, const int known_timeout) noexcept
-    : frequency(frequency), known_timeout(known_timeout) {}
-    constexpr_f1 PlayerConfig(const int frequency, const int known_timeout, const std::endian endian, const bool probe) noexcept
-    : frequency(frequency), known_timeout(known_timeout), endian(endian), probe(probe) {}
+    constexpr_f1 PlayerConfig(const Player player, const int frequency) noexcept
+    : player(player), frequency(frequency) {}
+    constexpr_f1 PlayerConfig(const Player player, const int frequency, const int known_timeout) noexcept
+    : player(player), frequency(frequency), known_timeout(known_timeout) {}
+    constexpr_f1 PlayerConfig(const Player player, const int frequency, const int known_timeout, const std::endian endian, const bool probe) noexcept
+    : player(player), frequency(frequency), known_timeout(known_timeout), endian(endian), probe(probe) {}
 };
 
 struct PlayerState {
@@ -106,7 +107,7 @@ void init() noexcept;
 void shutdown() noexcept;
 
 Player check(const char *path, const char *buf, size_t size) noexcept;
-std::optional<ModuleInfo> parse(const char *path, const char *buf, size_t size) noexcept;
+std::optional<ModuleInfo> parse(const char *path, const char *buf, size_t size, Player player = Player::NONE) noexcept;
 std::optional<PlayerState> play(const char *path, const char *buf, size_t size, int subsong, const PlayerConfig &config) noexcept;
 std::pair<common::SongEnd::Status, size_t> render(PlayerState &state, char *buf, size_t size) noexcept;
 bool stop(PlayerState &state) noexcept;
@@ -171,11 +172,11 @@ struct UADEConfig : PlayerConfig {
 
     constexpr_f1 UADEConfig() noexcept { player = Player::uade; }
     constexpr_f1 UADEConfig(const int frequency) noexcept
-    : PlayerConfig(frequency) { player = Player::uade; }
+    : PlayerConfig(Player::uade, frequency) {}
     constexpr_f1 UADEConfig(const int frequency, const int known_timeout, const std::endian endian, const bool probe) noexcept
-    : PlayerConfig(frequency, known_timeout, endian, probe) { player = Player::uade; }
+    : PlayerConfig(Player::uade, frequency, known_timeout, endian, probe) {}
     constexpr_f1 UADEConfig(const PlayerConfig &config) noexcept
-    : PlayerConfig(config.frequency, config.known_timeout, config.endian, config.probe) { player = Player::uade; }
+    : PlayerConfig(Player::uade, config.frequency, config.known_timeout, config.endian, config.probe) {}
 };
 
 bool seek(PlayerState &state, int millis) noexcept;
@@ -198,11 +199,11 @@ struct IT2PlayConfig : PlayerConfig {
 
     constexpr_f1 IT2PlayConfig() noexcept { player = Player::it2play; }
     constexpr_f1 IT2PlayConfig(const int frequency) noexcept
-    : PlayerConfig(frequency) { player = Player::it2play; }
+    : PlayerConfig(Player::it2play, frequency) {}
     constexpr_f1 IT2PlayConfig(const int frequency, const int known_timeout, const std::endian endian, const bool probe) noexcept
-    : PlayerConfig(frequency, known_timeout, endian, probe) { player = Player::it2play; }
+    : PlayerConfig(Player::it2play, frequency, known_timeout, endian, probe) {}
     constexpr_f1 IT2PlayConfig(const PlayerConfig &config) noexcept
-    : PlayerConfig(config.frequency, config.known_timeout, config.endian, config.probe) { player = Player::it2play; }
+    : PlayerConfig(Player::it2play, config.frequency, config.known_timeout, config.endian, config.probe) {}
 };
 
 } // namespace player::it2play

--- a/src/player/player.h
+++ b/src/player/player.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "common/std/optional.h"
+#include "common/std/string_view.h"
 
 #include <cassert>
 #include <cstddef>
@@ -14,6 +15,7 @@
 
 #include "common/compat.h"
 #include "common/constexpr.h"
+#include "common/foreach.h"
 #include "common/endian.h"
 #include "common/songend.h"
 #include "config.h"
@@ -42,27 +44,19 @@ constexpr int MAX_SILENCE = 3000;
     ft2play \
 )
 
+#define STRINGIFY(x) #x,
+constexpr char const *player_names[] = {
+    "NONE",
+    FOREACH(STRINGIFY, PLAYERS)
+};
+
 enum class Player {
     NONE,
     PLAYERS
 };
 
-constexpr_f2 std::string name(Player player) noexcept {
-    switch(player) {
-        case Player::hivelytracker: return "hivelytracker";
-        case Player::libdigibooster3: return "libdigibooster3";
-        case Player::uade: return "uade";
-        case Player::ft2play: return "ft2play";
-        case Player::st3play: return "st3play";
-        case Player::it2play: return "it2play";
-        case Player::st23play: return "st23play";
-        case Player::noisetrekker2: return "noisetrekker2";
-        case Player::protrekkr1: return "protrekkr1";
-        case Player::protrekkr2: return "protrekkr2";
-        default: assert(false); return "";
-    }
-    assert(false);
-    return "";
+constexpr std::string_view name(Player player) noexcept {
+    return player_names[static_cast<int>(player)];
 }
 
 struct ModuleInfo {

--- a/src/player/players/player_ft2play.cc
+++ b/src/player/players/player_ft2play.cc
@@ -231,7 +231,7 @@ struct FSTHeader {
 constexpr_f2 bool is_fasttracker2(const char *buf, size_t size) noexcept {
     if (size < sizeof(XMHeader) || memcmp(buf, "Extended Module:", 16)) return false;
     const auto &h = (const XMHeader *)buf;
-    if (h->ver < 0x0102 || h->ver > 0x104 ||
+    if (h->ver < 0x102 || h->ver > 0x104 ||
         h->antChn < 2 || h->antChn > 32 || (h->antChn & 1) != 0 ||
         h->len > 256 || h->antPtn > 256 || h->antInstrs > 128) {
         DEBUG("player_ft2play::parse failed - ver %d progName %s len %d antChn %d antPtn %d antInstrs %d\n", (int16_t)h->ver, h->progName, (int16_t)h->len, (int16_t)h->antChn, (int16_t)h->antPtn, (int16_t)h->antInstrs);
@@ -372,11 +372,13 @@ void init() noexcept {
 }
 
 void shutdown() noexcept {
+#ifdef PLAYER_PROBE
     probe::stopVoices();
     probe::mix_ClearChannels();
     probe::mix_Free();
     probe::freeMusic();
     probe::moduleLoaded = false;
+#endif
     play::stopVoices();
     play::mix_ClearChannels();
     play::mix_Free();

--- a/src/player/players/player_hivelytracker.cc
+++ b/src/player/players/player_hivelytracker.cc
@@ -34,24 +34,13 @@ constexpr_f2 ModuleInfo get_info(const string &path, struct hvl_tune *ht) noexce
     return {Player::hivelytracker, format, path, 0, maxsubsong, 0, channels};
 }
 
-bool initialized = false;
-mutex init_guard;
-void lazy_init() noexcept {
-    if (!initialized) {
-        init_guard.lock();
-        if (!initialized) {
-            hvl_InitReplayer();
-            initialized = true;
-        }
-        init_guard.unlock();
-    }
-}
-
 } // namespace {}
 
 namespace player::hivelytracker {
 
-void init() noexcept {}
+void init() noexcept {
+    hvl_InitReplayer();
+}
 
 void shutdown() noexcept {}
 
@@ -74,7 +63,6 @@ optional<ModuleInfo> parse(const char *path, const char *buf, size_t size) noexc
 
 optional<PlayerState> play(const char *path, const char *buf, size_t size, int subsong, const PlayerConfig &config) noexcept {
     assert(subsong >= 0);
-    lazy_init();
     struct hvl_tune *ht = hvl_reset((uint8_t*)buf, size, 0, config.frequency);
     if (!ht) {
         ERR("player_hivelytracker::play parsing failed for %s\n", path);

--- a/src/player/players/player_it2play.cc
+++ b/src/player/players/player_it2play.cc
@@ -398,8 +398,10 @@ void init() noexcept {
 }
 
 void shutdown() noexcept {
+#ifdef PLAYER_PROBE
     probe::Music_FreeSong();
     probe::Music_Close();
+#endif
     play::Music_FreeSong();
     play::Music_Close();
 }

--- a/src/player/players/player_noisetrekker2.cc
+++ b/src/player/players/player_noisetrekker2.cc
@@ -95,16 +95,20 @@ namespace player::noisetrekker2 {
 
 void init() noexcept {
     if (!play::AllocPattern()) assert(false);
+#ifdef PLAYER_PROBE
     if (!probe::AllocPattern()) assert(false);
+#endif
 }
 
 void shutdown() noexcept {
     play::SongStop();
     play::FreeAll();
     if (play::RawPatterns) free(play::RawPatterns);
+#ifdef PLAYER_PROBE
     probe::SongStop();
     probe::FreeAll();
     if (probe::RawPatterns) free(probe::RawPatterns);
+#endif
 }
 
 bool is_our_file(const char *path, const char *buf, size_t size) noexcept {

--- a/src/player/players/player_protrekkr1.cc
+++ b/src/player/players/player_protrekkr1.cc
@@ -75,17 +75,21 @@ namespace player::protrekkr1 {
 void init() noexcept {
     if (!play::Ptk_InitDriver()) assert(false);
     if (!play::Alloc_Patterns_Pool()) assert(false);
+#ifdef PLAYER_PROBE
     if (!probe::Ptk_InitDriver()) assert(false);
     if (!probe::Alloc_Patterns_Pool()) assert(false);
+#endif
 }
 
 void shutdown() noexcept {
     play::Ptk_Stop();
     play::Free_Samples();
     if (play::RawPatterns) free(play::RawPatterns);
+#ifdef PLAYER_PROBE
     probe::Ptk_Stop();
     probe::Free_Samples();
     if (probe::RawPatterns) free(probe::RawPatterns);
+#endif
 }
 
 bool is_our_file(const char *path, const char *buf, size_t size) noexcept {

--- a/src/player/players/player_protrekkr2.cc
+++ b/src/player/players/player_protrekkr2.cc
@@ -110,17 +110,21 @@ namespace player::protrekkr2 {
 void init() noexcept {
     if (!play::Ptk_InitDriver()) assert(false);
     if (!play::Alloc_Patterns_Pool()) assert(false);
+#ifdef PLAYER_PROBE
     if (!probe::Ptk_InitDriver()) assert(false);
     if (!probe::Alloc_Patterns_Pool()) assert(false);
+#endif
 }
 
 void shutdown() noexcept {
     play::Ptk_Stop();
     play::Free_Samples();
     if (play::RawPatterns) free(play::RawPatterns);
+#ifdef PLAYER_PROBE
     probe::Ptk_Stop();
     probe::Free_Samples();
     if (probe::RawPatterns) free(probe::RawPatterns);
+#endif
 }
 
 bool is_our_file(const char *path, const char *buf, size_t size) noexcept {

--- a/src/player/players/player_st23play.cc
+++ b/src/player/players/player_st23play.cc
@@ -122,8 +122,10 @@ namespace player::st23play {
 void init() noexcept {}
 
 void shutdown() noexcept {
+#ifdef PLAYER_PROBE
     probe::clearMixBuffer();
     probe::st23play_Close();
+#endif
     play::clearMixBuffer();
     play::st23play_Close();
 }

--- a/src/player/players/player_st3play.cc
+++ b/src/player/players/player_st3play.cc
@@ -292,9 +292,11 @@ namespace player::st3play {
 
 void init() noexcept {}
 void shutdown() noexcept {
+#ifdef PLAYER_PROBE
     probe::st3play_SetInterpolation(false);
     probe::clearMixBuffer();
     probe::st3play_Close();
+#endif
     play::st3play_SetInterpolation(false);
     play::clearMixBuffer();
     play::st3play_Close();

--- a/src/plugin/audacious/plugin.cc
+++ b/src/plugin/audacious/plugin.cc
@@ -156,7 +156,7 @@ bool update_tuple(Tuple &tuple, const string &path, int subsong, const Info &inf
     string codec = info.format;
     transform(codec.begin(), codec.end(), codec.begin(), ::tolower);
     if (codec != player) {
-        codec = info.format + " [" + player::name(info.player) + "]";
+        codec = info.format + " [" + player.data() + "]";
     } else {
         codec = info.format; // undo tolower
     }
@@ -336,24 +336,36 @@ public:
         "Copyright (c) 2014-2025, Matti Tiainen\n"
         PACKAGE_URL "\n"
         "\n"
+#if PLAYER_uade
         "UADE " UADE_VERSION " (GPL-2.0-or-later)\n"
         "https://zakalwe.fi/uade/\n"
         "\n"
+#endif
+#if PLAYER_hivelytracker
         "HivelyTracker 1.9 (BSD-3-Clause)\n"
         "Copyright (c) 2006-2018, Pete Gordon\n"
         "\n"
+#endif
+#if PLAYER_libdigibooster3
         "libdigibooster3 1.2 (BSD-2-Clause)\n"
         "Copyright (c) 2014, Grzegorz Kraszewski\n"
         "\n"
+#endif
+#if PLAYER_ft2play || PLAYER_it2play || PLAYER_st3play || PLAYER_st23play
         "ft2play, it2play, st3play v1.0.1,\n"
         "st23play v0.35 (BSD-3-Clause)\n"
         "Copyright (c) 2016-2024, Olav Sørensen\n"
         "\n"
+#endif
+#if PLAYER_protrekkr1 || PLAYER_protrekkr2
         "ProTrekkr v1.99e, v2.8.1 (BSD-2-Clause)\n"
         "Copyright (C) 2008-2024, Franck Charlet\n"
         "\n"
+#endif
+#if PLAYER_noisetrekker2
         "NoiseTrekker2 final by Arguru\n"
         "\n"
+#endif
         "See README for more information\n",
         &plugin_prefs
     };

--- a/src/plugin/cli/player/player_main.cc
+++ b/src/plugin/cli/player/player_main.cc
@@ -59,13 +59,13 @@ int main(int argc, char *argv[]) {
         return EXIT_FAILURE;
     }
 
-    auto info = parse(fname, buffer.data(), buffer.size());
+    auto info = parse(fname, buffer.data(), buffer.size(), player);
     if (!info) {
         fprintf(stderr, "Could not parse %s\n", fname);
         return EXIT_FAILURE;
     }
 
-    PlayerConfig player_config = { frequency };
+    PlayerConfig player_config = { info->player, frequency };
     auto uade_config = uade::UADEConfig(player_config);
     if (getenv("SONGEND_MODE")) {
         uade_config.subsong_timeout = player::PRECALC_TIMEOUT;

--- a/src/plugin/cli/precalc/precalc_main.cc
+++ b/src/plugin/cli/precalc/precalc_main.cc
@@ -32,17 +32,17 @@ void print(const common::SongEnd &songend, const player::ModuleInfo &info, int s
     if (subsong == info.minsubsong) {
         const auto pl = player::name(info.player);
         if (includepath) {
-            fprintf(stdout, "%s\t%d\t%d\t%s\t%s\t%s\t%d\t%zu\t%s\n", md5hex.c_str(),subsong,songend.length,reason.c_str(),pl.c_str(),info.format.c_str(),info.channels,buf.size(),info.path.c_str());
+            fprintf(stdout, "%s\t%d\t%d\t%s\t%s\t%s\t%d\t%zu\t%s\n", md5hex.c_str(),subsong,songend.length,reason.c_str(),pl.data(),info.format.c_str(),info.channels,buf.size(),info.path.c_str());
         } else {
-            fprintf(stdout, "%s\t%d\t%d\t%s\t%s\t%s\t%d\t%zu\n", md5hex.c_str(),subsong,songend.length,reason.c_str(),pl.c_str(),info.format.c_str(),info.channels,buf.size());
+            fprintf(stdout, "%s\t%d\t%d\t%s\t%s\t%s\t%d\t%zu\n", md5hex.c_str(),subsong,songend.length,reason.c_str(),pl.data(),info.format.c_str(),info.channels,buf.size());
         }
     } else {
         fprintf(stdout, "%s\t%d\t%d\t%s\n", md5hex.c_str(),subsong,songend.length,reason.c_str());
     }
 }
 
-int player_songend(vector<char> &buf, const char *path, bool includepath, const string &md5hex) {
-    const auto &info = player::parse(path, buf.data(), buf.size());
+int player_songend(const player::Player player, vector<char> &buf, const char *path, bool includepath, const string &md5hex) {
+    const auto &info = player::parse(path, buf.data(), buf.size(), player);
     if (!info) {
         fprintf(stderr, "Could not parse %s md5 %s\n", path, md5hex.c_str());
         return EXIT_FAILURE;
@@ -119,8 +119,9 @@ int main(int argc, char *argv[]) {
 #endif
 
     const player::support::PlayerScope p;
-    if (player::check(path, buffer.data(), buffer.size()) != player::Player::NONE) {
-        int res = player_songend(buffer, path, includepath, md5hex);
+    const auto player = player::check(path, buffer.data(), buffer.size());
+    if (player != player::Player::NONE) {
+        int res = player_songend(player, buffer, path, includepath, md5hex);
         return res;
     } else {
         fprintf(stderr, "Could not recognize %s md5 %s\n", path, md5hex.c_str());

--- a/src/songend/precalc.cc
+++ b/src/songend/precalc.cc
@@ -102,7 +102,7 @@ SongEnd precalc_song_end(const ModuleInfo &info, const char *buf, size_t size, i
     const auto check_stop = []() { return false; };
     const auto check_seek = []() { return -1; };
     int frequency = PRECALC_FREQ;
-    const player::PlayerConfig player_config = { frequency, 0, endian::native, true };
+    player::PlayerConfig player_config = { info.player, frequency, 0, endian::native, true };
     auto uade_config = player::uade::UADEConfig(player_config);
     uade_config.silence_timeout = SILENCE_TIMEOUT;
     auto it2play_config = it2play::IT2PlayConfig(player_config);


### PR DESCRIPTION
- make probe namespaces optional
-- build by default only with audacious plugin
- avoid unnecessary player rechecks in parse() and play()
- lazy init all players
